### PR TITLE
WL-3031 SIGNUP-218 Quote titles correctly.

### DIFF
--- a/impl/src/bundle/emailMessage.properties
+++ b/impl/src/bundle/emailMessage.properties
@@ -3,18 +3,18 @@
 #ui.service=Classes*v2
 #
 
-subject.new.appointment.field=Meeting assignment by '{0}' for meeting {2} on {1}
-subject.attendee.signup.field={1} has signed up for the meeting '{3}' on {0} in {2} 
-subject.Cancel.appointment.field=Appointment for meeting '{2}' on {0} has been canceled by {1}
-subject.meeting.modification.field={0} has modified the meeting '{4}' for {1} on {2},{3}
-subject.meeting.cancel.field=Appointment for meeting '{0}' in {1} has been canceled
-subject.newMeeting.field=New meeting '{2}' announced by {0} on {1}
-subject.organizer.change.appointment.field=Meeting '{2}' on {0} {1} has been changed
-subject.organizerPreAssign.appointment.field=Meeting assignment for '{2}' by {0} on {1}
-subject.promote.appointment.field=Promoted from wait list for meeting '{1}' on {0}
-subject.auto.reminder.appointment.field=Your upcoming appointment for '{3}' on {0},{1},{2}
-subject.attendee.signup.own.field=You have signed up for the meeting '{0}' in {1}
-subject.attendee.cancel.own.field=You have cancelled your appointment for the meeting '{0}' in {1}
+subject.new.appointment.field=Meeting assignment by ''{0}'' for meeting {2} on {1}
+subject.attendee.signup.field={1} has signed up for the meeting ''{3}'' on {0} in {2}
+subject.Cancel.appointment.field=Appointment for meeting ''{2}'' on {0} has been canceled by {1}
+subject.meeting.modification.field={0} has modified the meeting ''{4}'' for {1} on {2},{3}
+subject.meeting.cancel.field=Appointment for meeting ''{0}'' in {1} has been canceled
+subject.newMeeting.field=New meeting ''{2}'' announced by {0} on {1}
+subject.organizer.change.appointment.field=Meeting ''{2}'' on {0} {1} has been changed
+subject.organizerPreAssign.appointment.field=Meeting assignment for ''{2}'' by {0} on {1}
+subject.promote.appointment.field=Promoted from wait list for meeting ''{1}'' on {0}
+subject.auto.reminder.appointment.field=Your upcoming appointment for ''{3}'' on {0},{1},{2}
+subject.attendee.signup.own.field=You have signed up for the meeting ''{0}'' in {1}
+subject.attendee.cancel.own.field=You have cancelled your appointment for the meeting ''{0}'' in {1}
 
 noReply@=postmaster@
 


### PR DESCRIPTION
When the name of the meeting was introduced the quotes around the title weren't correctly written resulting in the title not getting subsituted.
