### PR TITLE
WL-3676 Only let people who can use tool see it.

### DIFF
--- a/tool/src/webapp/tools/sakai.signup.xml
+++ b/tool/src/webapp/tools/sakai.signup.xml
@@ -4,7 +4,7 @@
 		title="Sign-up"
 		description="For enabling online registration for meetings and other events.">
 		
-		<!-- <configuration name="functions.require" value="signup.view|signup.view.all" /> -->
+		<configuration name="functions.require" value="signup.view|signup.view.all" />
 		<configuration name="signup.other.sites.availability" value="default" />
 		<category name="course" />
 		<category name="project" />


### PR DESCRIPTION
Anonymous users can’t use the signup tool as it uses the SessionManager to get IDs which results in nulls for the anonymous user. Switching to the UserDriectoryService which returns empty strings is a little risky and would need lots of testing to so mask the issue we’ll just hide the tool from those users won’t can’t use it.
